### PR TITLE
improved performance by reducing intermediate arrays

### DIFF
--- a/clientside.js
+++ b/clientside.js
@@ -16,9 +16,18 @@ const trimMiddle = (str, length = 16, replaceString = "…") => {
         return str;
     }
 
+    let res = "";
     let remainder = (length - replaceString.length) / 2;
-    let chunks = [...new Intl.Segmenter().segment(str)].map(x => x.segment);
-    return chunks.slice(0, Math.ceil(remainder)).join("") +
-            replaceString +
-            chunks.slice(-Math.floor(remainder)).join("");
+    let head = Math.ceil(remainder);
+    let tail = [];
+    let i = 0;
+    for (let { segment } of new Intl.Segmenter().segment(str)) {
+        if (i < head) {
+            res += segment;
+        } else {
+            tail.push(segment);
+        }
+        i++;
+    }
+    return res + replaceString + tail.slice(-Math.floor(remainder)).join("");
 };

--- a/index.js
+++ b/index.js
@@ -16,10 +16,19 @@ const trimMiddle = (str, length = 16, replaceString = "…") => {
         return str;
     }
 
+    let res = "";
     let remainder = (length - replaceString.length) / 2;
-    let chunks = [...new Intl.Segmenter().segment(str)].map(x => x.segment);
-    return chunks.slice(0, Math.ceil(remainder)).join("") +
-            replaceString +
-            chunks.slice(-Math.floor(remainder)).join("");
+    let head = Math.ceil(remainder);
+    let tail = [];
+    let i = 0;
+    for (let { segment } of new Intl.Segmenter().segment(str)) {
+        if (i < head) {
+            res += segment;
+        } else {
+            tail.push(segment);
+        }
+        i++;
+    }
+    return res + replaceString + tail.slice(-Math.floor(remainder)).join("");
 };
 export { trimMiddle };


### PR DESCRIPTION
As discussed in https://github.com/codepo8/trimMiddle/pull/2#discussion_r1902040358, this proposes adding a bit more code to (hopefully) improve runtime performance.

However, I'm no performance expert and haven't actually benchmarked or profiled this yet (timeboxing my efforts here), so this might be the start of a discussion rather than a ready-made patch: It's possible that my assumptions here about engines' behavior are plain wrong or out of date.

> previously there were multiple arrays for segmented chunks as well as head and tail of the resulting string
>
> allocating such intermediate arrays might become a significant factor in garbage collection if our function is invoked frequently, so we're avoiding this by iterating over segmented chunks instead
>
> note that for small strings, concatenation is (supposedly, as of today?) more performant than joining an intermediate array - however, for the tail part, we won't know how many entries we need until we've processed them all (due to Unicode vagaries, which is why we use `Intl.Segmenter` in the first place), so we do need an intermediate array there

FWIW, I've also created a simplistic test file for myself to ensure I didn't break anything, executed via `node --test`:

```javascript
// index.test.js
import { trimMiddle } from "./index.js";
import { test } from "node:test";
import { strictEqual } from "node:assert";

test("basics", () => {
    let txt = "This 🇺🇳 is 🤡 🐥 a string 🥰 🧑‍🧑‍🧒‍🧒 with compound emoji 😊 ";
    strictEqual(trimMiddle(txt), "This 🇺🇳 i…moji 😊 ");
});
```