### PR TITLE
minor performance and syntax tweaks

### DIFF
--- a/clientside.js
+++ b/clientside.js
@@ -17,11 +17,11 @@ const trimMiddle = (str, length = 16, replaceString = "…") => {
     }
 
     let res = "";
-    let remainder = (length - replaceString.length) / 2;
-    let head = Math.ceil(remainder);
-    let tail = [];
+    const remainder = (length - replaceString.length) / 2;
+    const head = Math.ceil(remainder);
+    const tail = [];
     let i = 0;
-    for (let { segment } of new Intl.Segmenter().segment(str)) {
+    for (const { segment } of new Intl.Segmenter().segment(str)) {
         if (i < head) {
             res += segment;
         } else {
@@ -29,6 +29,6 @@ const trimMiddle = (str, length = 16, replaceString = "…") => {
         }
         i++;
     }
-    let end = Math.floor(remainder); 
+    const end = Math.floor(remainder);
     return res + replaceString + (end > 0 ? tail.slice(-end).join("") : "");
 };

--- a/clientside.js
+++ b/clientside.js
@@ -30,5 +30,5 @@ const trimMiddle = (str, length = 16, replaceString = "…") => {
         i++;
     }
     let end = Math.floor(remainder); 
-    return res + replaceString + (end > 0 ? tail.slice(-Math.floor(remainder)).join("") : '');
+    return res + replaceString + (end > 0 ? tail.slice(-end).join("") : "");
 };

--- a/index.js
+++ b/index.js
@@ -17,11 +17,11 @@ const trimMiddle = (str, length = 16, replaceString = "…") => {
     }
 
     let res = "";
-    let remainder = (length - replaceString.length) / 2;
-    let head = Math.ceil(remainder);
-    let tail = [];
+    const remainder = (length - replaceString.length) / 2;
+    const head = Math.ceil(remainder);
+    const tail = [];
     let i = 0;
-    for (let { segment } of new Intl.Segmenter().segment(str)) {
+    for (const { segment } of new Intl.Segmenter().segment(str)) {
         if (i < head) {
             res += segment;
         } else {
@@ -29,7 +29,7 @@ const trimMiddle = (str, length = 16, replaceString = "…") => {
         }
         i++;
     }
-    let end = Math.floor(remainder); 
+    const end = Math.floor(remainder);
     return res + replaceString + (end > 0 ? tail.slice(-end).join("") : "");
 };
 export { trimMiddle };

--- a/index.js
+++ b/index.js
@@ -30,6 +30,6 @@ const trimMiddle = (str, length = 16, replaceString = "…") => {
         i++;
     }
     let end = Math.floor(remainder); 
-    return res + replaceString + (end > 0 ? tail.slice(-Math.floor(remainder)).join("") : '');
+    return res + replaceString + (end > 0 ? tail.slice(-end).join("") : "");
 };
 export { trimMiddle };


### PR DESCRIPTION
* replaced redundant calculation
* fixed quotation marks for consistency
* fixed trailing whitespace
* replaced `let` with `const` where warranted (just because we already use `const` elsewhere)

While I'm not too keen on `const` myself, it irked me that I had introduced this inconsistency in my previous PRs - so I used [Deno's linter and formatter](https://prepitaph.org/articles/banishing-npm/) to improve overall consistency. The rest were things I noticed along the way.